### PR TITLE
Update ticket link to GDG Ibadan community event Page

### DIFF
--- a/app/component/DevfestHero.tsx
+++ b/app/component/DevfestHero.tsx
@@ -74,7 +74,8 @@ const DevfestHero = () => {
             </div>
             <div className="flex flex-col md:flex-row gap-3 md:gap-5 text-sm'">
               <Link
-                href="/ticket"
+                 href="https://gdg.community.dev/e/mrbzpf/"
+              target="_blank"
                 className="bg-black py-4 px-52 text-white hover:bg-core-blue hover:text-white rounded-[100px] flex"
               >
                 Get Ticket <ArrowUpRight />

--- a/app/component/Venue.tsx
+++ b/app/component/Venue.tsx
@@ -35,7 +35,8 @@ const Venue = () => {
             <div className="w-full md:w-2/3 flex flex-col gap-10">
               <div className="flex flex-row items-center justify-between">
                 <h1 className="font-bold text-2xl md:text-5xl">The venue</h1>
-                <Link href="/ticket">
+                <Link href="https://gdg.community.dev/e/mrbzpf/"
+              target="_blank">
                   <Button className="text-sm md:text-xl rounded-[100px] bg-black text-white hover:bg-core-blue px-20 md:px-52 py-4 md:py-10 hidden md:flex items-center">
                     Get Ticket
                     <ArrowUpRight />


### PR DESCRIPTION
This pull request updates the ticket links on the website to point to the external GDG event page instead of an internal route. The links now open in a new tab for better user experience.

**Ticket Link Updates:**

* Updated the "Get Ticket" button in `DevfestHero.tsx` to link to the external GDG event page and open in a new tab.
* Updated the "Get Ticket" button in `Venue.tsx` to link to the external GDG event page and open in a new tab.