### PR TITLE
Feat/deactivate admin

### DIFF
--- a/backend/src/modules/admin/admin.controller.ts
+++ b/backend/src/modules/admin/admin.controller.ts
@@ -203,26 +203,26 @@ export class AdminController {
     return this.adminService.inviteAdmin(inviteDto, user.sub);
   }
 
-  // @Patch('deactivate/:id')
-  // @ApiBearerAuth()
-  // @UseGuards(JwtAuthGuard, PermissionsGuard)
-  // @RequirePermission('admins.deactivate')
-  // @ApiOperation({ summary: 'Deactivate an admin account (Super Admin only)' })
-  // @ApiOkResponse({
-  //   description: 'Admin deactivated successfully',
-  //   type: AdminActionResponseDto,
-  // })
-  // @ApiResponse({
-  //   status: 403,
-  //   description: 'Only SUPER_ADMIN can deactivate other admins.',
-  // })
-  // @HttpCode(HttpStatus.OK)
-  // async deactivateAdmin(
-  //   @Param('id') adminId: string,
-  //   @CurrentUser() user: IJwtPayload,
-  // ) {
-  //   return this.adminService.deactivateAdmin(adminId, user.sub);
-  // }
+  @Patch('deactivate/:id')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @RequirePermission('admins.deactivate')
+  @ApiOperation({ summary: 'Deactivate an admin account (Super Admin only)' })
+  @ApiOkResponse({
+    description: 'Admin deactivated successfully',
+    type: AdminActionResponseDto,
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Only SUPER_ADMIN can deactivate other admins.',
+  })
+  @HttpCode(HttpStatus.OK)
+  async deactivateAdmin(
+    @Param('id') adminId: string,
+    @CurrentUser() user: IJwtPayload,
+  ) {
+    return this.adminService.deactivateAdmin(adminId, user.sub);
+  }
 
   @Get()
   @ApiBearerAuth()
@@ -239,20 +239,4 @@ export class AdminController {
   async findAll(@Query() query: AdminQueryDto) {
     return this.adminService.findAll(query);
   }
-
-  // @Patch('status')
-  // @ApiBearerAuth()
-  // @UseGuards(JwtAuthGuard, RolesGuard)
-  // @Roles(Role.SUPER_ADMIN)
-  // @ApiOperation({
-  //   summary: 'Update an admin account status (Super Admin only)',
-  // })
-  // @ApiResponse({
-  //   status: 200,
-  //   description: 'Admin status updated successfully.',
-  // })
-  // @ApiResponse({ status: 401, description: 'Unauthorized.' })
-  // async updateStatus(@Body() dto: UpdateAdminStatusDto) {
-  //   return this.adminService.updateStatus(dto.adminId, dto.isActive);
-  // }
 }

--- a/backend/src/modules/admin/admin.controller.ts
+++ b/backend/src/modules/admin/admin.controller.ts
@@ -224,21 +224,21 @@ export class AdminController {
   //   return this.adminService.deactivateAdmin(adminId, user.sub);
   // }
 
-  // @Get()
-  // @ApiBearerAuth()
-  // @RequirePermission('admins.list')
-  // @UseGuards(JwtAuthGuard, PermissionsGuard)
-  // @ApiOperation({
-  //   summary: 'Get all admins',
-  // })
-  // @ApiOkResponse({
-  //   description: 'Admins retrieved successfully.',
-  //   type: FindAllAdminsResponseDto,
-  // })
-  // @ApiResponse({ status: 401, description: 'Unauthorized.' })
-  // async findAll(@Query() query: AdminQueryDto) {
-  //   return this.adminService.findAll(query);
-  // }
+  @Get()
+  @ApiBearerAuth()
+  @RequirePermission('admins.list')
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @ApiOperation({
+    summary: 'Get all admins',
+  })
+  @ApiOkResponse({
+    description: 'Admins retrieved successfully.',
+    type: FindAllAdminsResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized.' })
+  async findAll(@Query() query: AdminQueryDto) {
+    return this.adminService.findAll(query);
+  }
 
   // @Patch('status')
   // @ApiBearerAuth()

--- a/backend/src/modules/admin/admin.controller.ts
+++ b/backend/src/modules/admin/admin.controller.ts
@@ -124,20 +124,20 @@ export class AdminController {
     return this.adminService.resetPassword(resetPasswordDto);
   }
 
-  // @Get('findOne')
-  // @ApiBearerAuth()
-  // @RequirePermission('admins.profile')
-  // @UseGuards(JwtAuthGuard, PermissionsGuard)
-  // @ApiOperation({ summary: 'Get the authenticated admin profile' })
-  // @ApiOkResponse({
-  //   description: 'Profile retrieved successfully.',
-  //   type: FindOneAdminResponseDto,
-  // })
-  // @ApiResponse({ status: 401, description: 'Unauthorized.' })
-  // @HttpCode(HttpStatus.OK)
-  // async getProfile(@CurrentUser() user: IJwtPayload): Promise<IAdminResponse> {
-  //   return this.adminService.findOne(user.sub);
-  // }
+  @Get('findOne')
+  @ApiBearerAuth()
+  @RequirePermission('admins.profile')
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @ApiOperation({ summary: 'Get the authenticated admin profile' })
+  @ApiOkResponse({
+    description: 'Profile retrieved successfully.',
+    type: FindOneAdminResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized.' })
+  @HttpCode(HttpStatus.OK)
+  async getProfile(@CurrentUser() user: IJwtPayload): Promise<IAdminResponse> {
+    return this.adminService.findOne(user.sub);
+  }
 
   @Patch('profile')
   @ApiBearerAuth()

--- a/backend/src/modules/admin/admin.service.ts
+++ b/backend/src/modules/admin/admin.service.ts
@@ -403,68 +403,68 @@ export class AdminService {
   //   return { message: 'Admin deactivated successfully' };
   // }
 
-  // async findAll(query: AdminQueryDto) {
-  //   const { search, role, isActive, page = 1, limit = 10 } = query;
-  //   const skip = (page - 1) * limit;
+  async findAll(query: AdminQueryDto) {
+    const { search, role, isActive, page = 1, limit = 10 } = query;
+    const skip = (page - 1) * limit;
 
-  //   const where: any = {};
+    const where: any = {};
 
-  //   if (search) {
-  //     where.OR = [
-  //       { fullName: { contains: search, mode: 'insensitive' } },
-  //       { email: { contains: search, mode: 'insensitive' } },
-  //     ];
-  //   }
+    if (search) {
+      where.OR = [
+        { fullName: { contains: search, mode: 'insensitive' } },
+        { email: { contains: search, mode: 'insensitive' } },
+      ];
+    }
 
-  //   if (role) {
-  //     where.role = { name: { equals: role, mode: 'insensitive' } };
-  //   }
+    if (role) {
+      where.role = { name: { equals: role, mode: 'insensitive' } };
+    }
 
-  //   if (typeof isActive === 'boolean') {
-  //     where.isActive = isActive;
-  //   }
+    if (typeof isActive === 'boolean') {
+      where.isActive = isActive;
+    }
 
-  //   const [admins, total] = await Promise.all([
-  //     this.prisma.admin.findMany({
-  //       where,
-  //       skip,
-  //       take: limit,
-  //       orderBy: { createdAt: 'desc' },
-  //       select: {
-  //         id: true,
-  //         fullName: true,
-  //         email: true,
-  //         role: {
-  //           select: {
-  //             name: true,
-  //             permissions: true,
-  //           },
-  //         },
-  //         isActive: true,
-  //         invitedById: true,
-  //         createdAt: true,
-  //         updatedAt: true,
-  //       },
-  //     }),
-  //     this.prisma.admin.count({ where }),
-  //   ]);
+    const [admins, total] = await Promise.all([
+      this.prisma.admin.findMany({
+        where,
+        skip,
+        take: limit,
+        orderBy: { createdAt: 'desc' },
+        select: {
+          id: true,
+          fullName: true,
+          email: true,
+          role: {
+            select: {
+              name: true,
+              permissions: true,
+            },
+          },
+          isActive: true,
+          invitedById: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      }),
+      this.prisma.admin.count({ where }),
+    ]);
 
-  //   return {
-  //     data: admins.map((admin) => ({
-  //       ...admin,
-  //       role: {
-  //         name: admin.role?.name ?? '',
-  //         permissions: (admin.role?.permissions ?? []) as PERMISSION_ID[],
-  //       },
-  //     })),
-  //     meta: {
-  //       total,
-  //       page,
-  //       limit,
-  //       totalPages: Math.ceil(total / limit),
-  //     },
-  //   };
-  // }
+    return {
+      data: admins.map((admin) => ({
+        ...admin,
+        role: {
+          name: admin.role?.name ?? '',
+          permissions: (admin.role?.permissions ?? []) as PERMISSION_ID[],
+        },
+      })),
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
 
   // async findOne(id: string): Promise<IAdminResponse> {
   //   const admin = await this.prisma.admin.findUnique({

--- a/backend/src/modules/admin/admin.service.ts
+++ b/backend/src/modules/admin/admin.service.ts
@@ -365,43 +365,43 @@ export class AdminService {
     };
   }
 
-  // async deactivateAdmin(
-  //   adminId: string,
-  //   deactivatedBy: string,
-  // ): Promise<{ message: string }> {
-  //   if (adminId === deactivatedBy) {
-  //     throw new ForbiddenException('You cannot deactivate your own account');
-  //   }
+  async deactivateAdmin(
+    adminId: string,
+    deactivatedBy: string,
+  ): Promise<{ message: string }> {
+    if (adminId === deactivatedBy) {
+      throw new ForbiddenException('You cannot deactivate your own account');
+    }
 
-  //   const target = await this.prisma.admin.findUnique({
-  //     where: { id: adminId },
-  //   });
+    const target = await this.prisma.admin.findUnique({
+      where: { id: adminId },
+    });
 
-  //   if (!target) {
-  //     throw new NotFoundException('Admin not found');
-  //   }
+    if (!target) {
+      throw new NotFoundException('Admin not found');
+    }
 
-  //   if (!target.isActive) {
-  //     throw new BadRequestException('Admin account is already deactivated');
-  //   }
+    if (!target.isActive) {
+      throw new BadRequestException('Admin account is already deactivated');
+    }
 
-  //   await this.prisma.$transaction(async (tx) => {
-  //     await tx.admin.update({
-  //       where: { id: adminId },
-  //       data: { isActive: false },
-  //     });
+    await this.prisma.$transaction(async (tx) => {
+      await tx.admin.update({
+        where: { id: adminId },
+        data: { isActive: false },
+      });
 
-  //     await tx.auditLog.create({
-  //       data: {
-  //         adminId: deactivatedBy,
-  //         action: 'DEACTIVATE_ADMIN',
-  //         metadata: { targetAdminId: adminId },
-  //       },
-  //     });
-  //   });
+      await tx.auditLog.create({
+        data: {
+          adminId: deactivatedBy,
+          action: 'DEACTIVATE_ADMIN',
+          metadata: { targetAdminId: adminId },
+        },
+      });
+    });
 
-  //   return { message: 'Admin deactivated successfully' };
-  // }
+    return { message: 'Admin deactivated successfully' };
+  }
 
   async findAll(query: AdminQueryDto) {
     const { search, role, isActive, page = 1, limit = 10 } = query;
@@ -492,15 +492,6 @@ export class AdminService {
       include: { role: true },
     });
   }
-
-  // async updateStatus(id: string, isActive: boolean) {
-  //   await this.findOne(id);
-  //   return await this.prisma.admin.update({
-  //     where: { id },
-  //     data: { isActive },
-  //     include: { role: true },
-  //   });
-  // }
 
   private generateAuthTokens(payload: IJwtPayload): AuthTokens {
     const accessToken = this.jwtService.sign(payload, {

--- a/backend/src/modules/admin/admin.service.ts
+++ b/backend/src/modules/admin/admin.service.ts
@@ -466,25 +466,25 @@ export class AdminService {
     };
   }
 
-  // async findOne(id: string): Promise<IAdminResponse> {
-  //   const admin = await this.prisma.admin.findUnique({
-  //     where: { id },
-  //     include: { role: true },
-  //   });
+  async findOne(id: string): Promise<IAdminResponse> {
+    const admin = await this.prisma.admin.findUnique({
+      where: { id },
+      include: { role: true },
+    });
 
-  //   if (!admin) {
-  //     throw new NotFoundException('Admin not found');
-  //   }
+    if (!admin) {
+      throw new NotFoundException('Admin not found');
+    }
 
-  //   const { password, roleId, role, ...rest } = admin;
-  //   return {
-  //     ...rest,
-  //     role: {
-  //       name: role?.name ?? '',
-  //       permissions: (role?.permissions ?? []) as PERMISSION_ID[],
-  //     },
-  //   };
-  // }
+    const { password, roleId, role, ...rest } = admin;
+    return {
+      ...rest,
+      role: {
+        name: role?.name ?? '',
+        permissions: (role?.permissions ?? []) as PERMISSION_ID[],
+      },
+    };
+  }
 
   async findByEmail(email: string) {
     return await this.prisma.admin.findUnique({


### PR DESCRIPTION
## Description

Implemented an admin deactivation endpoint that allows authorized administrators with the `admins.deactivate` permission to deactivate another admin account.

### What was added

- Added `PATCH /admins/deactivate/:id` endpoint.
- Added `deactivateAdmin` service method.
- Prevented an administrator from deactivating their own account.
- Added validation to ensure the target admin exists.
- Added validation to prevent deactivating an already inactive account.
- Updated the target admin's `isActive` status to `false`.
- Added an audit log entry for every successful deactivation.
- Wrapped the admin update and audit log creation in a Prisma transaction.
- Protected the endpoint with JWT authentication and the `admins.deactivate` permission.
- Added Swagger documentation and appropriate HTTP responses.

### Motivation

This endpoint provides controlled deactivation of admin accounts while preserving accountability through audit logging. It also prevents administrators from accidentally disabling their own accounts.

### Dependencies

No new external dependencies were required for this change.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

The endpoint was tested locally using Swagger/API client with the following scenarios:

- [x] Successfully deactivate an active admin.
- [x] Verify that the target admin's `isActive` value changes to `false`.
- [x] Verify that an audit log is created after successful deactivation.
- [x] Verify that an admin cannot deactivate their own account.
- [x] Verify that a non-existent admin returns `404 Not Found`.
- [x] Verify that an already deactivated admin returns an appropriate error.
- [x] Verify that unauthenticated requests are rejected.
- [x] Verify that users without the `admins.deactivate` permission are rejected.
- [x] Verify that the admin update and audit log are handled within the same transaction.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if appropriate):

Not applicable.