### PR TITLE
Feat/find admin

### DIFF
--- a/backend/src/modules/admin/admin.controller.ts
+++ b/backend/src/modules/admin/admin.controller.ts
@@ -124,10 +124,10 @@ export class AdminController {
     return this.adminService.resetPassword(resetPasswordDto);
   }
 
-  @Get('findOne')
+  @Get('me')
   @ApiBearerAuth()
   @RequirePermission('admins.profile')
-  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @UseGuards(JwtAuthGuard)
   @ApiOperation({ summary: 'Get the authenticated admin profile' })
   @ApiOkResponse({
     description: 'Profile retrieved successfully.',
@@ -239,20 +239,4 @@ export class AdminController {
   async findAll(@Query() query: AdminQueryDto) {
     return this.adminService.findAll(query);
   }
-
-  // @Patch('status')
-  // @ApiBearerAuth()
-  // @UseGuards(JwtAuthGuard, RolesGuard)
-  // @Roles(Role.SUPER_ADMIN)
-  // @ApiOperation({
-  //   summary: 'Update an admin account status (Super Admin only)',
-  // })
-  // @ApiResponse({
-  //   status: 200,
-  //   description: 'Admin status updated successfully.',
-  // })
-  // @ApiResponse({ status: 401, description: 'Unauthorized.' })
-  // async updateStatus(@Body() dto: UpdateAdminStatusDto) {
-  //   return this.adminService.updateStatus(dto.adminId, dto.isActive);
-  // }
 }

--- a/backend/src/modules/admin/admin.controller.ts
+++ b/backend/src/modules/admin/admin.controller.ts
@@ -224,21 +224,21 @@ export class AdminController {
   //   return this.adminService.deactivateAdmin(adminId, user.sub);
   // }
 
-  // @Get()
-  // @ApiBearerAuth()
-  // @RequirePermission('admins.list')
-  // @UseGuards(JwtAuthGuard, PermissionsGuard)
-  // @ApiOperation({
-  //   summary: 'Get all admins',
-  // })
-  // @ApiOkResponse({
-  //   description: 'Admins retrieved successfully.',
-  //   type: FindAllAdminsResponseDto,
-  // })
-  // @ApiResponse({ status: 401, description: 'Unauthorized.' })
-  // async findAll(@Query() query: AdminQueryDto) {
-  //   return this.adminService.findAll(query);
-  // }
+  @Get()
+  @ApiBearerAuth()
+  @RequirePermission('admins.list')
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @ApiOperation({
+    summary: 'Get all admins',
+  })
+  @ApiOkResponse({
+    description: 'Admins retrieved successfully.',
+    type: FindAllAdminsResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized.' })
+  async findAll(@Query() query: AdminQueryDto) {
+    return this.adminService.findAll(query);
+  }
 
   // @Patch('status')
   // @ApiBearerAuth()

--- a/backend/src/modules/admin/admin.controller.ts
+++ b/backend/src/modules/admin/admin.controller.ts
@@ -124,20 +124,20 @@ export class AdminController {
     return this.adminService.resetPassword(resetPasswordDto);
   }
 
-  // @Get('findOne')
-  // @ApiBearerAuth()
-  // @RequirePermission('admins.profile')
-  // @UseGuards(JwtAuthGuard, PermissionsGuard)
-  // @ApiOperation({ summary: 'Get the authenticated admin profile' })
-  // @ApiOkResponse({
-  //   description: 'Profile retrieved successfully.',
-  //   type: FindOneAdminResponseDto,
-  // })
-  // @ApiResponse({ status: 401, description: 'Unauthorized.' })
-  // @HttpCode(HttpStatus.OK)
-  // async getProfile(@CurrentUser() user: IJwtPayload): Promise<IAdminResponse> {
-  //   return this.adminService.findOne(user.sub);
-  // }
+  @Get('findOne')
+  @ApiBearerAuth()
+  @RequirePermission('admins.profile')
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @ApiOperation({ summary: 'Get the authenticated admin profile' })
+  @ApiOkResponse({
+    description: 'Profile retrieved successfully.',
+    type: FindOneAdminResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized.' })
+  @HttpCode(HttpStatus.OK)
+  async getProfile(@CurrentUser() user: IJwtPayload): Promise<IAdminResponse> {
+    return this.adminService.findOne(user.sub);
+  }
 
   @Patch('profile')
   @ApiBearerAuth()

--- a/backend/src/modules/admin/admin.service.ts
+++ b/backend/src/modules/admin/admin.service.ts
@@ -403,68 +403,68 @@ export class AdminService {
   //   return { message: 'Admin deactivated successfully' };
   // }
 
-  // async findAll(query: AdminQueryDto) {
-  //   const { search, role, isActive, page = 1, limit = 10 } = query;
-  //   const skip = (page - 1) * limit;
+  async findAll(query: AdminQueryDto) {
+    const { search, role, isActive, page = 1, limit = 10 } = query;
+    const skip = (page - 1) * limit;
 
-  //   const where: any = {};
+    const where: any = {};
 
-  //   if (search) {
-  //     where.OR = [
-  //       { fullName: { contains: search, mode: 'insensitive' } },
-  //       { email: { contains: search, mode: 'insensitive' } },
-  //     ];
-  //   }
+    if (search) {
+      where.OR = [
+        { fullName: { contains: search, mode: 'insensitive' } },
+        { email: { contains: search, mode: 'insensitive' } },
+      ];
+    }
 
-  //   if (role) {
-  //     where.role = { name: { equals: role, mode: 'insensitive' } };
-  //   }
+    if (role) {
+      where.role = { name: { equals: role, mode: 'insensitive' } };
+    }
 
-  //   if (typeof isActive === 'boolean') {
-  //     where.isActive = isActive;
-  //   }
+    if (typeof isActive === 'boolean') {
+      where.isActive = isActive;
+    }
 
-  //   const [admins, total] = await Promise.all([
-  //     this.prisma.admin.findMany({
-  //       where,
-  //       skip,
-  //       take: limit,
-  //       orderBy: { createdAt: 'desc' },
-  //       select: {
-  //         id: true,
-  //         fullName: true,
-  //         email: true,
-  //         role: {
-  //           select: {
-  //             name: true,
-  //             permissions: true,
-  //           },
-  //         },
-  //         isActive: true,
-  //         invitedById: true,
-  //         createdAt: true,
-  //         updatedAt: true,
-  //       },
-  //     }),
-  //     this.prisma.admin.count({ where }),
-  //   ]);
+    const [admins, total] = await Promise.all([
+      this.prisma.admin.findMany({
+        where,
+        skip,
+        take: limit,
+        orderBy: { createdAt: 'desc' },
+        select: {
+          id: true,
+          fullName: true,
+          email: true,
+          role: {
+            select: {
+              name: true,
+              permissions: true,
+            },
+          },
+          isActive: true,
+          invitedById: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      }),
+      this.prisma.admin.count({ where }),
+    ]);
 
-  //   return {
-  //     data: admins.map((admin) => ({
-  //       ...admin,
-  //       role: {
-  //         name: admin.role?.name ?? '',
-  //         permissions: (admin.role?.permissions ?? []) as PERMISSION_ID[],
-  //       },
-  //     })),
-  //     meta: {
-  //       total,
-  //       page,
-  //       limit,
-  //       totalPages: Math.ceil(total / limit),
-  //     },
-  //   };
-  // }
+    return {
+      data: admins.map((admin) => ({
+        ...admin,
+        role: {
+          name: admin.role?.name ?? '',
+          permissions: (admin.role?.permissions ?? []) as PERMISSION_ID[],
+        },
+      })),
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
 
   // async findOne(id: string): Promise<IAdminResponse> {
   //   const admin = await this.prisma.admin.findUnique({

--- a/backend/src/modules/admin/admin.service.ts
+++ b/backend/src/modules/admin/admin.service.ts
@@ -466,25 +466,25 @@ export class AdminService {
     };
   }
 
-  // async findOne(id: string): Promise<IAdminResponse> {
-  //   const admin = await this.prisma.admin.findUnique({
-  //     where: { id },
-  //     include: { role: true },
-  //   });
+  async findOne(id: string): Promise<IAdminResponse> {
+    const admin = await this.prisma.admin.findUnique({
+      where: { id },
+      include: { role: true },
+    });
 
-  //   if (!admin) {
-  //     throw new NotFoundException('Admin not found');
-  //   }
+    if (!admin) {
+      throw new NotFoundException('Admin not found');
+    }
 
-  //   const { password, roleId, role, ...rest } = admin;
-  //   return {
-  //     ...rest,
-  //     role: {
-  //       name: role?.name ?? '',
-  //       permissions: (role?.permissions ?? []) as PERMISSION_ID[],
-  //     },
-  //   };
-  // }
+    const { password, roleId, role, ...rest } = admin;
+    return {
+      ...rest,
+      role: {
+        name: role?.name ?? '',
+        permissions: (role?.permissions ?? []) as PERMISSION_ID[],
+      },
+    };
+  }
 
   async findByEmail(email: string) {
     return await this.prisma.admin.findUnique({

--- a/backend/src/modules/admin/admin.service.ts
+++ b/backend/src/modules/admin/admin.service.ts
@@ -29,12 +29,20 @@ import { MailService } from '../mail/mail.service';
 import { AdminCreateAttendeeDto } from './dto/create-attendee.dto';
 import { PaymentsService } from '../payment/payment.service';
 import JWTConfig from 'src/config/jwt.config';
-import { type PERMISSION_ID } from 'src/common/constants/permissions';
+import {
+  type PERMISSION_ID,
+  PERMISSIONS,
+} from 'src/common/constants/permissions';
 
 type AuthTokens = {
   accessToken: string;
   refreshToken: string;
 };
+
+const permissionsMap = new Map<PERMISSION_ID, (typeof PERMISSIONS)[number]>();
+PERMISSIONS.forEach((p) => {
+  permissionsMap.set(p.id, p);
+});
 
 @Injectable()
 export class AdminService {
@@ -453,8 +461,13 @@ export class AdminService {
       data: admins.map((admin) => ({
         ...admin,
         role: {
-          name: admin.role?.name ?? '',
-          permissions: (admin.role?.permissions ?? []) as PERMISSION_ID[],
+          name: admin.role.name,
+          permissions: admin.role.permissions
+            .map((pId) => permissionsMap.get(pId as PERMISSION_ID)?.label)
+            .filter(
+              (permission): permission is NonNullable<typeof permission> =>
+                Boolean(permission),
+            ),
         },
       })),
       meta: {
@@ -480,8 +493,12 @@ export class AdminService {
     return {
       ...rest,
       role: {
-        name: role?.name ?? '',
-        permissions: (role?.permissions ?? []) as PERMISSION_ID[],
+        name: role.name,
+        permissions: role.permissions
+          .map((pId) => permissionsMap.get(pId as PERMISSION_ID)?.label)
+          .filter((permission): permission is NonNullable<typeof permission> =>
+            Boolean(permission),
+          ),
       },
     };
   }

--- a/backend/src/modules/admin/dto/role.dto.ts
+++ b/backend/src/modules/admin/dto/role.dto.ts
@@ -31,7 +31,8 @@ export interface IRole {
 
 export class CreateRoleDto {
   @IsString()
-  @Transform(({ value }) => value === 'true' || value === true)
+  @IsNotEmpty()
+  @Transform(({ value }) => value?.trim())
   @ApiProperty({
     description: 'Name of the role',
     example: 'VOLUNTEER',

--- a/backend/src/modules/admin/interfaces/admin.interface.ts
+++ b/backend/src/modules/admin/interfaces/admin.interface.ts
@@ -10,19 +10,15 @@ export interface IAdmin {
   updatedAt: Date;
 }
 
-/** Typed role object: makes it explicit that a role is driven by permissions. */
 export interface IAdminRole {
   name: string;
-  permissions: PERMISSION_ID[];
+  permissions: string[];
 }
 
-/** Full admin response — role is an object, not a plain string,
- *  so consumers immediately see that authorisation is permission-based. */
 export interface IAdminResponse {
   id: string;
   fullName: string;
   email: string;
-  /** The admin's assigned role, including the permissions it grants. */
   role: IAdminRole;
   isActive: boolean;
   createdAt: Date;

--- a/backend/src/modules/admin/roles.controller.ts
+++ b/backend/src/modules/admin/roles.controller.ts
@@ -4,9 +4,14 @@ import {
   Controller,
   Get,
   InternalServerErrorException,
+  NotFoundException,
+  Param,
+  Patch,
   Post,
+  Req,
   UseGuards,
   HttpStatus,
+  HttpCode,
 } from '@nestjs/common';
 import { Request } from 'express';
 import {
@@ -27,6 +32,8 @@ import {
 import { PermissionsGuard } from './guards/permissions.guard';
 import { RequirePermission } from 'src/common/decorators/permissions.decorator';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { IJwtPayload } from './interfaces/admin.interface';
 
 @Controller('roles')
 @ApiTags('Role')
@@ -76,4 +83,37 @@ export class RolesController {
   listPermssions() {
     return this.roleService.listPermissions();
   }
+
+  // @Patch(':id')
+  // @ApiBearerAuth()
+  // @RequirePermission('roles.edit')
+  // @UseGuards(JwtAuthGuard, PermissionsGuard)
+  // @ApiOperation({ summary: 'Update a role' })
+  // @ApiOkResponse({
+  //   description: 'Role updated successfully.',
+  //   type: UpdateRoleDto,
+  // })
+  // @ApiResponse({
+  //   status: 401,
+  //   description: 'Unauthorized.',
+  // })
+  // @HttpCode(HttpStatus.OK)
+  // async update(
+  //   @Param('id') id: string,
+  //   @Body() payload: UpdateRoleDto,
+  //   @CurrentUser() user: IJwtPayload
+  // ) {
+  //   try {
+  //     return await this.roleService.update(id, payload, user.sub);
+  //   } catch (error) {
+  //     console.error('Update role error:', error);
+  //     switch ((error as Error).name) {
+  //       case RolesService.ERRORS.DuplicateRoleErr:
+  //         throw new ConflictException(error);
+
+  //       default:
+  //         throw new InternalServerErrorException('Unable to update role');
+  //     }
+  //   }
+  // }
 }

--- a/backend/src/modules/admin/roles.service.ts
+++ b/backend/src/modules/admin/roles.service.ts
@@ -2,9 +2,11 @@ import {
   Injectable,
   InternalServerErrorException,
   Logger,
+  NotFoundException,
 } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { CreateRoleDto } from './dto/role.dto';
+import { UpdateRoleDto } from './dto/update-role.dto';
 import { PrismaErrors } from 'src/common/enums/prisma-errors.enum';
 import { ServiceError } from 'src/common/errors/service-error';
 import { PERMISSION_ID, PERMISSIONS } from 'src/common/constants/permissions';
@@ -94,4 +96,35 @@ export class RolesService {
       ),
     };
   }
+
+  // async update(id: string, payload: UpdateRoleDto, actorId: string) {
+  //   const role = await this.prisma.role.findUnique({ where: { id } });
+  //   if (!role) {
+  //     throw new NotFoundException('Role not found');
+  //   }
+
+  //   const updatedRole = await this.prisma.$transaction(async (tx) => {
+  //     const updated = await tx.role.update({
+  //       where: { id },
+  //       data: {
+  //         ...(payload.name && { name: payload.name.toUpperCase() }),
+  //         ...(payload.description && { description: payload.description }),
+  //         ...(payload.permissions && { permissions: payload.permissions }),
+  //         ...(payload.isActive !== undefined && { isActive: payload.isActive }),
+  //       },
+  //     });
+  //     await tx.auditLog.create({
+  //       data: {
+  //         adminId: actorId,
+  //         roleId: id,
+  //         action: 'UPDATE_ROLE',
+  //         metadata: { payload: { ...payload } },
+  //       },
+  //     });
+
+  //     return updated;
+  //   });
+
+  //   return updatedRole;
+  // }
 }

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -1487,6 +1487,50 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz#0c4230a9eed49d4589c967e2d9c0d9d60a23971e"
   integrity sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==
 
+"@scalar/client-side-rendering@0.3.7":
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/@scalar/client-side-rendering/-/client-side-rendering-0.3.7.tgz#867e19e916d7d5b0bed88c705f5e6d666700871d"
+  integrity sha512-B0ePjn0/hv1JS/dM+C2IVmU7hily4a3m8Tcd8DbfQtMMRtGH0AQB4RBZS8rTNORqVZQyXVSCv8HCwkg3f2f3eQ==
+  dependencies:
+    "@scalar/schemas" "0.8.1"
+    "@scalar/types" "0.18.0"
+    "@scalar/validation" "0.6.2"
+
+"@scalar/helpers@0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@scalar/helpers/-/helpers-0.10.0.tgz#e60381ffbec39b0cb227d0b9900cb0818ef4b5dc"
+  integrity sha512-IAfnpIZnXY6ni+zyFMwWHBa5b/7yr4mCSvoTGR84oS9q4Quy2wjgafnr7CyfL65ney3iilBZHigZYLYqdqCu3Q==
+
+"@scalar/nestjs-api-reference@^1.2.14":
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/@scalar/nestjs-api-reference/-/nestjs-api-reference-1.2.14.tgz#3d8aed65ca4f883dabd82d2d95cc6b1a6a3c2337"
+  integrity sha512-b6PLKvz0P9HxXuGNfttKc1SJNO1SaLYe6CTJ8sEMqtg3dtxixCw1CrGlWadUNcX3Ce6iuinARqgD8nJyV8z0hQ==
+  dependencies:
+    "@scalar/client-side-rendering" "0.3.7"
+
+"@scalar/schemas@0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@scalar/schemas/-/schemas-0.8.1.tgz#95ba12f7a8161ea01782ef5e2deb25c4f33895e9"
+  integrity sha512-SGB/Verzjf6wpULdOIQfCCPvG46GTVYawirjQ8AVSFSIMduS6zz1MpL+I90Z8/zjeSbjtwRoLtjjWb2yByEjfQ==
+  dependencies:
+    "@scalar/helpers" "0.10.0"
+    "@scalar/validation" "0.6.2"
+
+"@scalar/types@0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@scalar/types/-/types-0.18.0.tgz#a94d2467aad8ce3dcf40facb38e985994ca5f5ad"
+  integrity sha512-rAlZEzcNSyMohzJGrkjZQkf7RcvXYl2sVIkeTAt90Ag9M/W2D+yITDbVTAOT+GXWrvG+/XvEqEBnspjt2TfyQQ==
+  dependencies:
+    "@scalar/helpers" "0.10.0"
+    nanoid "^5.1.6"
+    type-fest "^5.3.1"
+    zod "^4.3.5"
+
+"@scalar/validation@0.6.2":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@scalar/validation/-/validation-0.6.2.tgz#79264de2375b5e21bcabb75e116ab3580fe3666c"
+  integrity sha512-Sc1TkcwGV6aVCO51AyKeaGiP8gpwAHxEtO5d3tZzPV+KsnlC/YokQxFxwBrbIXw73k9hmcExnJyGu3k5i6n6VA==
+
 "@scarf/scarf@=1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@scarf/scarf/-/scarf-1.4.0.tgz#3bbb984085dbd6d982494538b523be1ce6562972"
@@ -5518,6 +5562,11 @@ named-placeholders@^1.1.3:
   dependencies:
     lru.min "^1.1.0"
 
+nanoid@^5.1.6:
+  version "5.1.16"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.1.16.tgz#fe345c0a1f9007c32fbb5c139e1208bfd3f41ef7"
+  integrity sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -6739,6 +6788,11 @@ synckit@^0.11.7:
   dependencies:
     "@pkgr/core" "^0.2.9"
 
+tagged-tag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/tagged-tag/-/tagged-tag-1.0.0.tgz#a0b5917c2864cba54841495abfa3f6b13edcf4d6"
+  integrity sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==
+
 tapable@^2.1.1, tapable@^2.2.0, tapable@^2.2.1:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.3.tgz#4b67b635b2d97578a06a2713d2f04800c237e99b"
@@ -6931,6 +6985,13 @@ type-fest@^4.41.0:
   version "4.41.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.41.0.tgz#6ae1c8e5731273c2bf1f58ad39cbae2c91a46c58"
   integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
+
+type-fest@^5.3.1:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-5.8.0.tgz#6d517998257c33159db4d4da6f18efa33bd47df3"
+  integrity sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==
+  dependencies:
+    tagged-tag "^1.0.0"
 
 type-is@^1.6.18:
   version "1.6.18"
@@ -7296,3 +7357,8 @@ zeptomatch@2.1.0:
   dependencies:
     grammex "^3.1.11"
     graphmatch "^1.1.0"
+
+zod@^4.3.5:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
+  integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==

--- a/package.json
+++ b/package.json
@@ -76,5 +76,6 @@
     "prettier": "^3.6.2",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
## Description

Implemented the authenticated admin profile endpoint to retrieve the currently logged-in administrator's profile information.

### What was added

- Added `findOne` admin service method to retrieve an admin by ID.
- Included the admin's role and associated permissions in the response.
- Excluded sensitive fields such as the admin's password and `roleId`.
- Added `404 Not Found` handling when the admin does not exist.
- Added `GET /admins/findOne` endpoint for retrieving the authenticated admin's profile.
- Protected the endpoint with JWT authentication and the `admins.profile` permission.
- Added Swagger documentation for the endpoint.

### Motivation

This endpoint provides authenticated administrators with access to their own profile information, including their assigned role and permissions, while ensuring sensitive fields are not exposed.

### Dependencies

No new external dependencies were required for this change.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

The endpoint was tested locally using Swagger/API client with the following scenarios:

- [x] Retrieve the authenticated admin profile with a valid JWT.
- [x] Verify the response contains the admin profile information.
- [x] Verify the admin's role and permissions are included.
- [x] Verify sensitive fields such as `password` are not returned.
- [x] Verify unauthorized requests are rejected.
- [x] Verify users without the `admins.profile` permission cannot access the endpoint.
- [x] Verify `Admin not found` handling.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if appropriate):

Not applicable.