### PR TITLE
Add admin authentication pages

### DIFF
--- a/app/_module/components/AuthBg/index.tsx
+++ b/app/_module/components/AuthBg/index.tsx
@@ -1,19 +1,8 @@
 'use client';
 
-import React, { ReactNode, useEffect } from 'react';
+import React, { ReactNode } from 'react';
 
 const AuthBg = ({ children }: { children: ReactNode }) => {
-  // Lock body scroll while any auth page is mounted
-  useEffect(() => {
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-    document.documentElement.style.overflow = 'hidden';
-    return () => {
-      document.body.style.overflow = prev;
-      document.documentElement.style.overflow = '';
-    };
-  }, []);
-
   return (
     <div
       style={{

--- a/app/_module/components/AuthBg/index.tsx
+++ b/app/_module/components/AuthBg/index.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import React, { ReactNode, useEffect } from 'react';
+
+const AuthBg = ({ children }: { children: ReactNode }) => {
+  // Lock body scroll while any auth page is mounted
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    document.documentElement.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+      document.documentElement.style.overflow = '';
+    };
+  }, []);
+
+  return (
+    <div
+      style={{
+        backgroundImage: "url('/pastel-blue-art.png')",
+        backgroundRepeat: 'no-repeat',
+        backgroundPosition: 'bottom',
+        backgroundSize: 'cover',
+        width: '100%',
+        height: '100vh',
+        overflow: 'hidden',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '0 16px',
+        position: 'fixed',
+      }}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default AuthBg;

--- a/app/_module/components/icons/PasswordChanged.tsx
+++ b/app/_module/components/icons/PasswordChanged.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+const PasswordChanged = () => {
+  return (
+    <svg
+      width="80"
+      height="80"
+      viewBox="0 0 80 80"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect
+        width="80"
+        height="80"
+        rx="40"
+        fill="#34A853"
+        fill-opacity="0.0823529"
+      />
+      <path
+        d="M53.332 30L35.0005 48.332L26.668 39.9993"
+        stroke="#34A853"
+        stroke-width="2"
+        stroke-linecap="round"
+      />
+    </svg>
+  );
+}
+
+export default PasswordChanged

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,5 +1,94 @@
-import { redirect } from 'next/navigation';
+'use client';
 
-export default function AdminPage() {
-  redirect('/admin/home');
+import { useState } from 'react';
+import Link from 'next/link';
+import { Eye, EyeOff } from 'lucide-react';
+import AuthBg from '../_module/components/AuthBg';
+
+export default function AdminSignInPage() {
+  const [email, setEmail] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
+  const [showPassword, setShowPassword] = useState<boolean>(false);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+  };
+
+  return (
+    <AuthBg>
+      <div className="w-full max-w-[460px] mx-auto">
+        <div className="bg-white rounded-2xl px-10 py-10 shadow-sm">
+          {/* Header */}
+          <div className="text-center mb-7">
+            <h1 className="text-[24px] font-bold text-[#1e1e1e] mb-2">
+              Admin Sign In
+            </h1>
+            <p className="text-[14px] text-[#5F6368]">
+              Access the DevFest Ibadan management console
+            </p>
+          </div>
+
+          <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+            {/* Email */}
+            <div>
+              <label className="block text-[13px] font-medium text-[#1e1e1e] mb-2">
+                Email Address
+              </label>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="organiser@devfestibadan.com"
+                required
+                className="w-full border border-gray-200 rounded-lg px-4 py-3 text-[13px] text-gray-800 placeholder:text-gray-400 focus:outline-none focus:border-gray-400 transition-colors bg-white"
+              />
+            </div>
+
+            {/* Password */}
+            <div>
+              <label className="block text-[13px] font-medium text-[#1e1e1e] mb-2">
+                Password
+              </label>
+              <div className="relative">
+                <input
+                  type={showPassword ? 'text' : 'password'}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="••••••••••"
+                  required
+                  className="w-full border border-gray-200 rounded-lg px-4 py-3 pr-11 text-[13px] text-gray-800 placeholder:text-gray-400 focus:outline-none focus:border-gray-400 transition-colors bg-white"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((v) => !v)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                >
+                  {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+                </button>
+              </div>
+
+              {/* Forgot password */}
+              <div className="flex justify-end mt-2">
+                <Link
+                  href="/forgot-password"
+                  className="text-[13px] text-[#4285F4] font-semibold hover:underline"
+                >
+                  Forgot Password?
+                </Link>
+              </div>
+            </div>
+
+            {/* Submit */}
+            <button
+              type="submit"
+              className="w-full py-3 rounded-lg bg-[#1e1e1e] text-white text-[14px] font-semibold hover:bg-black transition-colors mt-1"
+            >
+              Sign In
+            </button>
+          </form>
+        </div>
+      </div>
+    </AuthBg>
+  );
 }

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import AuthBg from '../_module/components/AuthBg';
+
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState<string>('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+  };
+
+  return (
+    <AuthBg>
+      <div className="w-full max-w-[460px] mx-auto">
+        <div className="bg-white rounded-2xl px-10 py-10 shadow-sm">
+          {/* Header */}
+          <div className="text-center mb-7">
+            <h1 className="text-[22px] font-bold text-[#1e1e1e] mb-2">Forgot Password?</h1>
+            <p className="text-[13px] text-gray-500 leading-relaxed">
+              Enter your email address and we&apos;ll send you a reset link to
+              regain access.
+            </p>
+          </div>
+
+          <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+            {/* Email */}
+            <div>
+              <label className="block text-[13px] font-medium text-[#1e1e1e] mb-2">
+                Email Address
+              </label>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="e.g. admin@devfestibadan.com"
+                required
+                className="w-full border border-gray-200 rounded-lg px-4 py-3 text-[13px] text-gray-800 placeholder:text-gray-400 focus:outline-none focus:border-gray-400 transition-colors bg-white"
+              />
+            </div>
+
+            {/* Submit */}
+            <button
+              type="submit"
+              className="w-full py-3 rounded-lg bg-[#1e1e1e] text-white text-[14px] font-semibold hover:bg-black transition-colors"
+            >
+              Send Reset Link
+            </button>
+
+            {/* Back to sign in */}
+            <Link
+              href="/admin"
+              className="flex items-center justify-center gap-2 text-[13px] text-[#1e1e1e] hover:underline font-medium"
+            >
+              <ArrowLeft size={15} />
+              Back to Sign In
+            </Link>
+          </form>
+        </div>
+      </div>
+    </AuthBg>
+  );
+}

--- a/app/layouts.tsx
+++ b/app/layouts.tsx
@@ -117,9 +117,14 @@ export default function RootLayout({
   const adminRoute = '/admin';
   const pathname = usePathname();
 
+  // Auth pages (/admin sign-in and /admin-auth/*) use HomeLayout — no sidenav
+  const isAdminSignIn = pathname === '/admin';
+  const isAdminAuth = pathname.startsWith('/admin-auth');
+  const isAdminDashboard = pathname.startsWith(adminRoute) && !isAdminSignIn;
+
   return (
     <Fragment>
-      {pathname.startsWith(adminRoute) ? (
+      {isAdminDashboard ? (
         <AdminLayout>{children}</AdminLayout>
       ) : (
         <HomeLayout>{children}</HomeLayout>

--- a/app/password-changed/page.tsx
+++ b/app/password-changed/page.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import Link from 'next/link';
+import AuthBg from '../_module/components/AuthBg';
+import PasswordChanged from '../_module/components/icons/PasswordChanged';
+
+export default function PasswordChangedPage() {
+  return (
+    <AuthBg>
+      <div className="w-full max-w-[460px] mx-auto">
+        <div className="bg-white rounded-2xl px-10 py-10 shadow-sm flex flex-col items-center gap-6 text-center">
+          {/* Green check circle */}
+          <PasswordChanged />
+          {/* Text */}
+          <div>
+            <h1 className="text-[22px] font-bold text-[#1e1e1e] mb-2">
+              Password Changed!
+            </h1>
+            <p className="text-[13px] text-gray-500 leading-relaxed">
+              Your password has been successfully updated. You can now sign in
+              with your new password.
+            </p>
+          </div>
+
+          {/* CTA */}
+          <Link href="/admin" className="w-full">
+            <button
+              type="button"
+              className="w-full py-3 rounded-[8px] bg-[#1e1e1e] text-white text-[14px] font-semibold hover:bg-black transition-colors"
+            >
+              Back to Sign In
+            </button>
+          </Link>
+        </div>
+      </div>
+    </AuthBg>
+  );
+}

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Eye, EyeOff } from 'lucide-react';
+import { cn } from '@/app/_module/lib/utils';
+import AuthBg from '../_module/components/AuthBg';
+
+type Strength = 'weak' | 'fair' | 'strong' | 'very-strong';
+
+function getStrength(password: string): Strength {
+  if (!password) return 'weak';
+  let score = 0;
+  if (password.length >= 8) score++;
+  if (password.length >= 12) score++;
+  if (/[A-Z]/.test(password) && /[a-z]/.test(password)) score++;
+  if (/[0-9]/.test(password)) score++;
+  if (/[^A-Za-z0-9]/.test(password)) score++;
+  if (score <= 1) return 'weak';
+  if (score === 2) return 'fair';
+  if (score === 3) return 'strong';
+  return 'very-strong';
+}
+
+const STRENGTH_CONFIG: Record<
+  Strength,
+  { label: string; color: string; bars: number }
+> = {
+  weak: { label: 'Weak', color: '#EF4444', bars: 1 },
+  fair: { label: 'Fair', color: '#F59E0B', bars: 2 },
+  strong: { label: 'Strong', color: '#3B82F6', bars: 3 },
+  'very-strong': { label: 'Very Strong', color: '#22C55E', bars: 4 },
+};
+
+function StrengthMeter({ password }: { password: string }) {
+  const strength = getStrength(password);
+  const { label, color, bars } = STRENGTH_CONFIG[strength];
+
+  return (
+    <div className="mt-2.5 space-y-1.5">
+      <div className="flex gap-1.5">
+        {[1, 2, 3, 4].map((i) => (
+          <div
+            key={i}
+            className="h-[4px] flex-1 rounded-[2px] transition-all duration-300"
+            style={{ backgroundColor: i <= bars ? color : '#E5E7EB' }}
+          />
+        ))}
+      </div>
+
+      <p className="text-[12px] font-medium" style={{ color }}>
+        {label} password
+      </p>
+    </div>
+  );
+}
+
+export default function ResetPasswordPage() {
+  const router = useRouter();
+  const [password, setPassword] = useState<string>('');
+  const [confirm, setConfirm] = useState<string>('');
+  const [showPassword, setShowPassword] = useState<boolean>(false);
+  const [showConfirm, setShowConfirm] = useState<boolean>(false);
+
+  const mismatch = confirm.length > 0 && password !== confirm;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (mismatch || !password || !confirm) return;
+    router.push('/password-changed');
+  };
+
+  return (
+    <AuthBg>
+      <div className="w-full max-w-[460px] mx-auto">
+        <div className="bg-white rounded-2xl px-10 py-10 shadow-sm">
+          {/* Header */}
+          <div className="text-center mb-7">
+            <h1 className="text-[22px] font-bold text-[#1e1e1e] mb-2">
+              Reset Password
+            </h1>
+            <p className="text-[13px] text-gray-500 leading-relaxed">
+              Choose a strong, unique password to secure your admin account.
+            </p>
+          </div>
+
+          <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+            {/* New Password */}
+            <div>
+              <label className="block text-[13px] font-medium text-[#1e1e1e] mb-2">
+                New Password
+              </label>
+              <div className="relative">
+                <input
+                  type={showPassword ? 'text' : 'password'}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="Enter new password"
+                  required
+                  className="w-full border border-gray-200 rounded-lg px-4 py-3 pr-11 text-[13px] text-gray-800 placeholder:text-gray-400 focus:outline-none focus:border-gray-400 transition-colors bg-white"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((v) => !v)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                >
+                  {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+                </button>
+              </div>
+              <StrengthMeter password={password} />
+            </div>
+
+            {/* Confirm Password */}
+            <div>
+              <label className="block text-[13px] font-medium text-[#1e1e1e] mb-2">
+                Confirm New Password
+              </label>
+              <div className="relative">
+                <input
+                  type={showConfirm ? 'text' : 'password'}
+                  value={confirm}
+                  onChange={(e) => setConfirm(e.target.value)}
+                  placeholder="Confirm new password"
+                  required
+                  className={cn(
+                    'w-full border rounded-lg px-4 py-3 pr-11 text-[13px] text-gray-800 placeholder:text-gray-400 focus:outline-none transition-colors bg-white',
+                    mismatch
+                      ? 'border-red-400 focus:border-red-400'
+                      : 'border-gray-200 focus:border-gray-400'
+                  )}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowConfirm((v) => !v)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+                  aria-label={showConfirm ? 'Hide password' : 'Show password'}
+                >
+                  {showConfirm ? <EyeOff size={18} /> : <Eye size={18} />}
+                </button>
+              </div>
+              {/* Red mismatch error */}
+              {mismatch && (
+                <p className="text-[12px] font-medium text-red-500 mt-1">
+                  Passwords do not match
+                </p>
+              )}
+            </div>
+
+            {/* Submit */}
+            <button
+              type="submit"
+              disabled={mismatch || !password || !confirm}
+              className="w-full py-3 rounded-lg bg-[#1e1e1e] text-white text-[14px] font-semibold hover:bg-black transition-colors disabled:opacity-50 disabled:cursor-not-allowed mt-1"
+            >
+              Reset Password
+            </button>
+          </form>
+        </div>
+      </div>
+    </AuthBg>
+  );
+}


### PR DESCRIPTION
## Description

This Pull request includes all the admin authentication pages such as signin, forgot password, reset password and password reset cornfirmation screen.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Yes this feature has been tested and it works perfectly well without any breaking changes

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

## Screenshots (if appropriate):
