### PR TITLE
refactor: avoid storing permissions in token

### DIFF
--- a/backend/src/modules/admin/admin.service.ts
+++ b/backend/src/modules/admin/admin.service.ts
@@ -71,10 +71,7 @@ export class AdminService {
     const tokens = this.generateAuthTokens({
       sub: admin.id,
       email: admin.email,
-      role: {
-        name: admin.role.name,
-        permissions: admin.role.permissions as PERMISSION_ID[],
-      },
+      roleId: admin.roleId,
     });
 
     return {
@@ -108,10 +105,7 @@ export class AdminService {
       return this.generateAuthTokens({
         sub: admin.id,
         email: admin.email,
-        role: {
-          name: admin.role.name,
-          permissions: admin.role.permissions as PERMISSION_ID[],
-        },
+        roleId: admin.roleId,
       });
     } catch (error) {
       this.logger.error(error);

--- a/backend/src/modules/admin/guards/permissions.guard.ts
+++ b/backend/src/modules/admin/guards/permissions.guard.ts
@@ -5,28 +5,31 @@ import {
   Injectable,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { Observable } from 'rxjs';
 import { type PERMISSION_ID } from 'src/common/constants/permissions';
 import { PERMISSION_KEY } from 'src/common/decorators/permissions.decorator';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { IJwtPayload } from '../interfaces/admin.interface';
 
 @Injectable()
 export class PermissionsGuard implements CanActivate {
-  constructor(private reflector: Reflector) {}
+  constructor(
+    private reflector: Reflector,
+    private prisma: PrismaService,
+  ) {}
 
-  canActivate(
-    context: ExecutionContext,
-  ): boolean | Promise<boolean> | Observable<boolean> {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const permission = this.reflector.getAllAndOverride<PERMISSION_ID>(
       PERMISSION_KEY,
       [context.getHandler(), context.getClass()],
     );
     if (!permission) return true;
 
-    const { user } = context.switchToHttp().getRequest();
-    if (
-      !user ||
-      !(user.role.permissions as PERMISSION_ID[]).includes(permission)
-    ) {
+    const { user } = context.switchToHttp().getRequest<{ user: IJwtPayload }>();
+    const role = await this.prisma.role.findFirstOrThrow({
+      where: { id: user.roleId },
+    });
+
+    if (!user || !(role.permissions as PERMISSION_ID[]).includes(permission)) {
       throw new ForbiddenException({
         message: 'Forbidden',
         success: false,

--- a/backend/src/modules/admin/interfaces/admin.interface.ts
+++ b/backend/src/modules/admin/interfaces/admin.interface.ts
@@ -32,10 +32,7 @@ export interface IAdminResponse {
 export interface IJwtPayload {
   sub: string;
   email: string;
-  role: {
-    name: string;
-    permissions: PERMISSION_ID[];
-  };
+  roleId: string;
   iat?: number;
   exp?: number;
 }


### PR DESCRIPTION
## Description

This PR removes permissions from being stored in the JWT. It stores the `roleId` only instead

## Type of change

- [ ] Refactor (non-breaking change which fixes an issue)

## How Has This Been Tested?

All authentication and authorization still work as expected.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if appropriate):
