### PR TITLE
fix: table name changes aftecting query raw

### DIFF
--- a/backend/src/modules/order/order.service.ts
+++ b/backend/src/modules/order/order.service.ts
@@ -1,11 +1,5 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import {
-  OrderStatus,
-  Prisma,
-  RefundStatus,
-  Ticket,
-  type Order,
-} from '@prisma/client';
+import { OrderStatus, Prisma, RefundStatus, type Order } from '@prisma/client';
 import { randomUUID } from 'node:crypto';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { ServiceError } from 'src/common/errors/service-error';
@@ -50,6 +44,39 @@ interface ProcessRefundPayload {
   refundId: string;
   orderId: string;
   provider: PaymentSuccessPayload['provider'];
+}
+
+interface OrderQueryRawResult {
+  id: string;
+  reference: string;
+  ticket_id: string;
+  attendee_full_name: string;
+  attendee_email: string;
+  attendee_phone_number: null | string;
+  gifter_name: null | string;
+  gifter_email: null | string;
+  discount: number;
+  amount: number;
+  currency: string;
+  status: string;
+  payment_provider: string;
+  provider_transaction_ref: string;
+  checkout_url: string;
+  expires_at: Date;
+  paid_at: any;
+  created_at: Date;
+  updated_at: Date;
+}
+
+interface TicketQueryRawResult {
+  id: string;
+  capacity: number;
+  price: Prisma.Decimal;
+  discount: Prisma.Decimal;
+  sale_starts_at: Date;
+  sale_ends_at: Date;
+  name: string;
+  slug: string;
 }
 
 @Injectable()
@@ -123,7 +150,7 @@ export class OrdersService {
       gifterEmail: string | null;
     },
   ): Promise<CreatedOrderRecord> {
-    const [ticket] = await tx.$queryRaw<Ticket[]>`
+    const [ticket] = await tx.$queryRaw<TicketQueryRawResult[]>`
     SELECT *
     FROM tickets
     WHERE slug = ${args.slug}
@@ -137,7 +164,7 @@ export class OrdersService {
     }
 
     const now = new Date();
-    if (now < ticket.saleStartsAt || now > ticket.saleEndsAt) {
+    if (now < ticket.sale_ends_at || now > ticket.sale_starts_at) {
       throw new ServiceError(
         'This ticket is not on sale',
         OrdersService.ERRORS.NotOnSaleErr,
@@ -308,7 +335,7 @@ export class OrdersService {
       try {
         txResult = await this.prisma.$transaction(
           async (tx) => {
-            const [order] = await tx.$queryRaw<Order[]>`
+            const [order] = await tx.$queryRaw<OrderQueryRawResult[]>`
             SELECT *
             FROM orders
             WHERE id = ${event.metaData.orderId}
@@ -330,8 +357,8 @@ Treating only ${OrderStatus.AWAITING_PAYMENT} orders`,
             }
 
             const transactionRefMismatch =
-              order.providerTransactionRef &&
-              order.providerTransactionRef !== event.transactionReference;
+              order.provider_transaction_ref &&
+              order.provider_transaction_ref !== event.transactionReference;
 
             // Since we're expecting only one currency now, this is fine
             const amountMismatch = event.amountPaid < Number(order.amount);
@@ -350,10 +377,10 @@ Treating only ${OrderStatus.AWAITING_PAYMENT} orders`,
             // Why are we doing this? To lock this row for any other concurrent
             // incoming events for this ticket to avoid other concurrent writes
             // affecting this tx
-            const [ticket] = await tx.$queryRaw<Ticket[]>`
+            const [ticket] = await tx.$queryRaw<TicketQueryRawResult[]>`
               SELECT *
-              FROM orders
-              WHERE id = ${order.ticketId}
+              FROM tickets
+              WHERE id = ${order.ticket_id}
               FOR UPDATE;
             `;
 
@@ -373,7 +400,7 @@ Initiating refund for order ${order.id}`,
             }
 
             const now = new Date();
-            const orderIsExpired = order.expiresAt < now;
+            const orderIsExpired = order.expires_at < now;
             const awaitingCount = await tx.order.count({
               where: {
                 ticketId: ticket.id,
@@ -436,7 +463,7 @@ Initiating refund for order ${order.id}`,
 
   private async recordRefund(
     tx: TxClient,
-    order: Order,
+    order: OrderQueryRawResult,
     payload: CreateRefundRecord,
   ): Promise<{ refundId: string; orderId: string }> {
     await tx.order.update({
@@ -447,8 +474,8 @@ Initiating refund for order ${order.id}`,
     const refund = await tx.refund.create({
       data: {
         orderId: order.id,
-        email: order.gifterEmail ?? order.attendeeEmail,
-        provider: order.paymentProvider,
+        email: order.gifter_email ?? order.attendee_email,
+        provider: order.payment_provider,
         transactionReference: payload.transactionReference,
         paymentReference: payload.paymentReference,
         refundReference: this.generateRefundReference(),

--- a/backend/src/modules/order/order.service.ts
+++ b/backend/src/modules/order/order.service.ts
@@ -11,7 +11,7 @@ import {
 } from '../payment/interfaces/payment-provider.interface';
 import { CreateOrderDto, CreateOrderResponseDto } from './create-order.dto';
 
-const ORDER_TTL_MINUTES = 10;
+const ORDER_TTL_MINUTES = 30;
 const TX_MAX_ATTEMPTS = 3;
 
 type TxClient = Prisma.TransactionClient;
@@ -164,7 +164,7 @@ export class OrdersService {
     }
 
     const now = new Date();
-    if (now < ticket.sale_ends_at || now > ticket.sale_starts_at) {
+    if (now < ticket.sale_starts_at || now > ticket.sale_ends_at) {
       throw new ServiceError(
         'This ticket is not on sale',
         OrdersService.ERRORS.NotOnSaleErr,

--- a/backend/src/modules/payment/monnify.service.ts
+++ b/backend/src/modules/payment/monnify.service.ts
@@ -18,7 +18,7 @@ import {
 } from './interfaces/monnify.interface';
 import monnifyConfig from 'src/config/monnify.config';
 
-const REQUEST_TIMEOUT_MS = 30_000;
+const REQUEST_TIMEOUT_MS = 10_000;
 const TOKEN_SAFETY_MARGIN_SEC = 60;
 
 @Injectable()


### PR DESCRIPTION
## Description

Changes in the column names caused a regression in Prisma `queryRaw` results in OrdersService.
This PR aims to fix them
This PR also reduces the TTL for Monnify queries (30 secs to 10 secs) and increases the expiration time for orders.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if appropriate):
