### PR TITLE
feat: list checked in attendees

### DIFF
--- a/backend/src/modules/attendee/attendee.controller.ts
+++ b/backend/src/modules/attendee/attendee.controller.ts
@@ -83,6 +83,7 @@ export class AttendeeController {
     } catch (err) {
       switch ((err as Error).name) {
         case AttendeeService.ERRORS.UnmatchedValidityDateErr:
+        case AttendeeService.ERRORS.CheckInUnpaidOrderErr:
           throw new BadRequestException((err as Error).message);
         case AttendeeService.ERRORS.TicketNotFoundErr:
           throw new NotFoundException((err as Error).message);

--- a/backend/src/modules/attendee/attendee.controller.ts
+++ b/backend/src/modules/attendee/attendee.controller.ts
@@ -2,10 +2,12 @@ import {
   BadRequestException,
   Body,
   Controller,
+  Get,
   HttpStatus,
   InternalServerErrorException,
   NotFoundException,
   Patch,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import {
@@ -16,6 +18,8 @@ import {
 } from '@nestjs/swagger';
 import { AttendeeService } from './attendee.service';
 import { CheckInOrderDto, CheckInResponseDto } from './dto/check-in.dto';
+import { CheckedInQueryDto } from './dto/checked-in.dto';
+import { CheckedInListResponseDto } from './dto/checked-in-response.dto';
 import { JwtAuthGuard } from '../admin/guards/jwt-auth.guard';
 import { PermissionsGuard } from '../admin/guards/permissions.guard';
 import { RequirePermission } from 'src/common/decorators/permissions.decorator';
@@ -24,6 +28,28 @@ import { RequirePermission } from 'src/common/decorators/permissions.decorator';
 @Controller('attendees')
 export class AttendeeController {
   constructor(private readonly attendeeService: AttendeeService) {}
+
+  @Get('checked-in')
+  @ApiBearerAuth()
+  @RequirePermission('attendees.list')
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @ApiOperation({
+    summary: 'List checked-in attendees',
+    description:
+      'Cursor-paginated list of checked-in attendees. By default returns earlier-created attendees first.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Checked-in orders retrieved successfully',
+    type: CheckedInListResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.FORBIDDEN,
+    description: 'Missing attendees.list permission',
+  })
+  checkedIn(@Query() query: CheckedInQueryDto) {
+    return this.attendeeService.checkedIn(query);
+  }
 
   @Patch('check-in')
   @ApiBearerAuth()

--- a/backend/src/modules/attendee/attendee.service.ts
+++ b/backend/src/modules/attendee/attendee.service.ts
@@ -4,9 +4,11 @@ import { PrismaService } from 'src/prisma/prisma.service';
 import { ServiceError } from 'src/common/errors/service-error';
 import { CheckInOrderDto } from './dto/check-in.dto';
 import { CheckedInQueryDto } from './dto/checked-in.dto';
+import { OrderStatus } from '@prisma/client';
 
 interface OrderCheckInRow {
   id: string;
+  status: OrderStatus;
   reference: string;
   ticket_id: string;
   check_ins: Date[];
@@ -31,6 +33,7 @@ export class AttendeeService {
   static ERRORS = {
     UnmatchedValidityDateErr: 'UnmatchedValidityDateErr',
     TicketNotFoundErr: 'TicketNotFoundErr',
+    CheckInUnpaidOrderErr: 'CheckInUnpaidOrderErr',
   } as const;
 
   constructor(private readonly prisma: PrismaService) {}
@@ -42,7 +45,7 @@ export class AttendeeService {
 
     return this.prisma.$transaction(async (tx) => {
       const [order] = await tx.$queryRaw<OrderCheckInRow[]>`
-        SELECT id, reference, ticket_id, check_ins
+        SELECT id, reference, status, ticket_id, check_ins
         FROM orders
         WHERE id = ${orderId}
         FOR UPDATE;`;
@@ -51,6 +54,13 @@ export class AttendeeService {
         throw new ServiceError(
           'Ticket not found',
           AttendeeService.ERRORS.TicketNotFoundErr,
+        );
+      }
+
+      if (order.status !== OrderStatus.PAID) {
+        throw new ServiceError(
+          'Cannot check-in unpaid order',
+          AttendeeService.ERRORS.CheckInUnpaidOrderErr,
         );
       }
 

--- a/backend/src/modules/attendee/attendee.service.ts
+++ b/backend/src/modules/attendee/attendee.service.ts
@@ -1,13 +1,29 @@
 import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { ServiceError } from 'src/common/errors/service-error';
 import { CheckInOrderDto } from './dto/check-in.dto';
+import { CheckedInQueryDto } from './dto/checked-in.dto';
 
 interface OrderCheckInRow {
   id: string;
   reference: string;
   ticket_id: string;
   check_ins: Date[];
+}
+
+interface CheckedInOrderRow {
+  id: string;
+  reference: string;
+  amount: Prisma.Decimal;
+  status: string;
+  attendee_full_name: string;
+  attendee_email: string;
+  paid_at: Date | null;
+  check_ins: Date[];
+  ticket_id: string;
+  ticket_name: string;
+  ticket_validity_dates: Date[];
 }
 
 @Injectable()
@@ -75,5 +91,71 @@ export class AttendeeService {
         checkIns: updated.checkIns,
       };
     });
+  }
+
+  async checkedIn(query: CheckedInQueryDto) {
+    const { eventDates, cursor, direction = 'next', limit = 20 } = query;
+
+    const cursorCondition = cursor
+      ? direction === 'next'
+        ? Prisma.sql`AND o.id > ${cursor}`
+        : Prisma.sql`AND o.id < ${cursor}`
+      : Prisma.empty;
+    const orderDirection = direction === 'next' ? 'ASC' : 'DESC';
+
+    const rows = await this.prisma.$queryRaw<CheckedInOrderRow[]>`
+      SELECT
+        o.id,
+        o.reference,
+        o.amount,
+        o.status,
+        o.attendee_full_name,
+        o.attendee_email,
+        o.paid_at,
+        o.check_ins,
+        t.id AS ticket_id,
+        t.name AS ticket_name,
+        t.validity_dates AS ticket_validity_dates
+      FROM orders o
+      JOIN tickets t ON t.id = o.ticket_id
+      WHERE EXISTS (
+        SELECT 1
+        FROM unnest(COALESCE(o.check_ins, ARRAY[]::timestamp(3)[])) AS c
+        WHERE c::date = ANY(${eventDates}::date[])
+      )
+      ${cursorCondition}
+      ORDER BY o.id ${Prisma.raw(orderDirection)}
+      LIMIT ${limit + 1};`;
+
+    const hasMore = rows.length > limit;
+    if (hasMore) rows.pop();
+
+    const data = rows.map((o) => ({
+      id: o.id,
+      paidAt: o.paid_at,
+      amount: Number(o.amount).toFixed(2),
+      status: o.status,
+      attendeeFullName: o.attendee_full_name,
+      attendeeEmail: o.attendee_email,
+      checkIns: o.check_ins,
+      ticket: {
+        id: o.ticket_id,
+        name: o.ticket_name,
+        code: o.reference.slice(-6),
+        validity: o.ticket_validity_dates
+          .map((d) => d.toLocaleDateString('en-US', { weekday: 'short' }))
+          .join(' + '),
+      },
+    }));
+
+    return {
+      data,
+      meta: {
+        nextCursor: hasMore ? (data[data.length - 1]?.id ?? null) : null,
+        prevCursor: cursor ?? null,
+        limit,
+        hasMore,
+      },
+    };
   }
 }

--- a/backend/src/modules/attendee/dto/checked-in-response.dto.ts
+++ b/backend/src/modules/attendee/dto/checked-in-response.dto.ts
@@ -31,7 +31,7 @@ export class CheckedInListItemDto {
     type: 'object',
     properties: {
       id: { type: 'string' },
-      name: { type: 'string', example: 'Early Bird' },
+      name: { type: 'string', example: 'Google DevFest 2026' },
       code: { type: 'string', example: 'ABC123' },
       validity: { type: 'string', example: 'Fri + Sat' },
     },

--- a/backend/src/modules/attendee/dto/checked-in-response.dto.ts
+++ b/backend/src/modules/attendee/dto/checked-in-response.dto.ts
@@ -1,0 +1,72 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { OrderStatus } from '@prisma/client';
+
+export class CheckedInListItemDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty({ type: Date, format: 'date-time', nullable: true })
+  paidAt: Date | null;
+
+  @ApiProperty({
+    type: String,
+    description: 'Amount paid in Naira (2 decimal places)',
+    example: '9500.00',
+  })
+  amount: string;
+
+  @ApiProperty({ enum: OrderStatus })
+  status: OrderStatus;
+
+  @ApiProperty()
+  attendeeFullName: string;
+
+  @ApiProperty()
+  attendeeEmail: string;
+
+  @ApiProperty({ type: [String], format: 'date-time' })
+  checkIns: Date[];
+
+  @ApiProperty({
+    type: 'object',
+    properties: {
+      id: { type: 'string' },
+      name: { type: 'string', example: 'Early Bird' },
+      code: { type: 'string', example: 'ABC123' },
+      validity: { type: 'string', example: 'Fri + Sat' },
+    },
+  })
+  ticket: { id: string; name: string; code: string; validity: string };
+}
+
+export class CheckedInPaginationMetaDto {
+  @ApiProperty({
+    type: String,
+    nullable: true,
+    description: 'Cursor to fetch the next page',
+  })
+  nextCursor: string | null;
+
+  @ApiProperty({
+    type: String,
+    nullable: true,
+    description: 'Cursor to fetch the previous page',
+  })
+  prevCursor: string | null;
+
+  @ApiProperty({ description: 'Number of results per page' })
+  limit: number;
+
+  @ApiProperty({
+    description: 'Whether more items exist in the direction of travel',
+  })
+  hasMore: boolean;
+}
+
+export class CheckedInListResponseDto {
+  @ApiProperty({ type: [CheckedInListItemDto] })
+  data: CheckedInListItemDto[];
+
+  @ApiProperty({ type: CheckedInPaginationMetaDto })
+  meta: CheckedInPaginationMetaDto;
+}

--- a/backend/src/modules/attendee/dto/checked-in.dto.ts
+++ b/backend/src/modules/attendee/dto/checked-in.dto.ts
@@ -1,0 +1,71 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsDateString,
+  IsIn,
+  IsInt,
+  IsOptional,
+  IsString,
+  Matches,
+  Max,
+  Min,
+} from 'class-validator';
+
+export class CheckedInQueryDto {
+  @ApiProperty({
+    description: 'Event dates to match check-ins against (YYYY-MM-DD)',
+    type: [String],
+    isArray: true,
+    required: true,
+    example: ['2026-09-20', '2026-09-21'],
+  })
+  @Transform(({ value }: { value: unknown }): string[] => {
+    if (Array.isArray(value)) return value as string[];
+    if (typeof value === 'string') return value.split(',');
+    return [];
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @IsDateString({}, { each: true })
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, {
+    each: true,
+    message: 'eventDates items must be in YYYY-MM-DD format',
+  })
+  eventDates!: string[];
+
+  @ApiPropertyOptional({
+    description:
+      'Pagination direction. `next` returns earlier-created attendees, `previous` returns more recent attendees.',
+    enum: ['next', 'previous'],
+    default: 'next',
+  })
+  @IsOptional()
+  @IsIn(['next', 'previous'])
+  direction?: 'next' | 'previous' = 'next';
+
+  @ApiPropertyOptional({
+    description:
+      'Cursor for pagination. Pass the ID of the last item from the previous page.',
+  })
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+
+  @ApiPropertyOptional({
+    description: 'Number of results to return per page',
+    example: 20,
+    default: 20,
+    minimum: 10,
+    maximum: 50,
+  })
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? Number.parseInt(value, 10) : value,
+  )
+  @IsOptional()
+  @IsInt()
+  @Min(10)
+  @Max(50)
+  limit?: number = 20;
+}

--- a/backend/src/modules/order/create-order.dto.ts
+++ b/backend/src/modules/order/create-order.dto.ts
@@ -55,7 +55,7 @@ export class OrderGifterDto {
 export class CreateOrderDto {
   @ApiProperty({
     description: 'Slug of the ticket to purchase',
-    example: 'early-bird-2026-08-17',
+    example: 'google-devfest-2026',
   })
   @IsString()
   @IsNotEmpty()
@@ -136,7 +136,7 @@ export class GetOrderReferenceResponseDto {
   @ApiProperty({
     type: 'object',
     properties: {
-      name: { type: 'string', example: 'Early Bird' },
+      name: { type: 'string', example: 'Google DevFest 2026' },
       url: {
         type: 'string',
         example: 'https://example.com/download/ticket.pdf',
@@ -258,7 +258,7 @@ export class OrderListItemDto {
     type: 'object',
     properties: {
       id: { type: 'string' },
-      name: { type: 'string', example: 'Early Bird' },
+      name: { type: 'string', example: 'Google DevFest 2026' },
       code: { type: 'string', example: 'ABC123' },
       validity: { type: 'string', example: 'Fri + Sat' },
     },

--- a/backend/src/modules/payment/monnify.service.ts
+++ b/backend/src/modules/payment/monnify.service.ts
@@ -59,7 +59,6 @@ export class MonnifyService implements PaymentProvider {
     const FEE_RATE = 0.015; // 1.5%
 
     amountInKobo = Math.trunc(amountInKobo);
-    this.logger.debug({ amountInKobo });
     const effectiveFeeRate = FEE_RATE * (1 + VAT_RATE);
     const effectiveCapKobo = Math.round(MONNIFY_CAP_CHARGE * (1 + VAT_RATE));
     const capThresholdKobo = Math.round(MONNIFY_CAP_CHARGE / FEE_RATE);

--- a/backend/src/modules/ticket/dto/ticket.dto.ts
+++ b/backend/src/modules/ticket/dto/ticket.dto.ts
@@ -51,7 +51,7 @@ export class TicketQueryDto {
 
   @ApiPropertyOptional({
     description: 'Ticket name (case-insensitive)',
-    example: 'Early Bird',
+    example: 'Google DevFest 2026',
   })
   @IsOptional()
   @IsString()
@@ -130,7 +130,7 @@ export class TicketListResponseDto {
 export class OnSaleTicketQueryDto {
   @ApiPropertyOptional({
     description: 'Filter tickets by name (case-insensitive)',
-    example: 'Early Bird',
+    example: 'Google DevFest 2026',
   })
   @IsOptional()
   @IsString()


### PR DESCRIPTION
## Description

This PR introduces changes that add a cursor-paginated endpoint to fetch a list of checked-in attendees for an event by event dates.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
```curl
curl '/api/v1/attendees/checked-in?eventDates=2026-09-17&eventDates=2026-09-18' \
  --header 'Accept: application/json' \
  --header 'Authorization: Bearer <token>'
```

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if appropriate):
