### PR TITLE
refactor: use single unique reference constraint in Orders table

### DIFF
--- a/backend/src/prisma/migrations/20260908140851_unique_order_reference/migration.sql
+++ b/backend/src/prisma/migrations/20260908140851_unique_order_reference/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX "orders_reference_provider_transaction_ref_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "orders_reference_key" ON "orders"("reference");

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -137,7 +137,7 @@ model Order {
 
   refund Refund?
 
-  @@unique([reference, providerTransactionRef])
+  @@unique([reference])
   @@index([ticketId, status])
   @@map("orders")
 }


### PR DESCRIPTION
## Description

Use single unique reference constraint in Orders table for quicker lookups

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if appropriate):
